### PR TITLE
Update project

### DIFF
--- a/src/main/java/es/jlarriba/jrmapi/Authentication.java
+++ b/src/main/java/es/jlarriba/jrmapi/Authentication.java
@@ -32,8 +32,10 @@ import java.util.UUID;
  */
 public class Authentication {
 
-    private static final String DEVICE_AUTH_URL = "https://my.remarkable.com/token/json/2/device/new";
-    private static final String USER_AUTH_URL = "https://my.remarkable.com/token/json/2/user/new";
+    private static final String DEVICE_AUTH_URL =
+            "https://webapp-production-dot-remarkable-production.appspot.com/token/json/2/device/new";
+    private static final String USER_AUTH_URL =
+            "https://webapp-production-dot-remarkable-production.appspot.com/token/json/2/user/new";
 
     private static final File RMAPI_PROPERTIES_FILE = new File(System.getProperty("user.home"), "/.rmapi");
     private static final String DEVICETOKEN_PROPERTY_NAME = "devicetoken";
@@ -63,6 +65,10 @@ public class Authentication {
      */
     public String userToken() {
         return net.post(USER_AUTH_URL, getDeviceToken());
+    }
+
+    public String userToken(String deviceToken) {
+        return net.post(USER_AUTH_URL, deviceToken);
     }
 
     protected String getDeviceToken() {

--- a/src/main/java/es/jlarriba/jrmapi/http/Net.java
+++ b/src/main/java/es/jlarriba/jrmapi/http/Net.java
@@ -1,5 +1,9 @@
 package es.jlarriba.jrmapi.http;
 
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
+
 import com.google.gson.Gson;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -121,7 +125,7 @@ public class Net {
     private void sendRequest(HttpRequest request, File file) {
         try {
             LOGGER.debug(request.uri());
-            var response = client.send(request, BodyHandlers.ofFile(file.toPath()));
+            var response = client.send(request, BodyHandlers.ofFile(file.toPath(), CREATE, WRITE, TRUNCATE_EXISTING));
             LOGGER.debug(response.statusCode());
         } catch (IOException | InterruptedException e) {
             LOGGER.error("Error while launching request", e);


### PR DESCRIPTION
This PR contains the following:
- Update the auth URLs which no longer worked.
- Add `fetchZip `method to download a document as zip to a supplied path.
- Add constructor with `deviceToken` parameter for clients wishing to store the credentials outside of the `RMAPI_PROPERTIES_FILE`.
- Return document ID on directory creation for working with a newly created document.
- Add `TRUNCATE` and other flags to `sendRequest` method to overwrite existing downloads.